### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Android ProgressBar that "bends" under its own weight.
 ![RopeProgressBar Animation](ropeprogressbar.gif)
 
 ---
-###Attributes
+### Attributes
 
 | Attribute                | Type      | Default                       | Usage                                                        |
 | ------------------------ | --------- | ----------------------------- | ------------------------------------------------------------ |
@@ -21,7 +21,7 @@ Android ProgressBar that "bends" under its own weight.
 
 
 ---
-###Download
+### Download
 
 ```groovy
 repositories {
@@ -36,11 +36,11 @@ dependencies {
 ```
 
 ---
-###Developed By
+### Developed By
 - Christian De Angelis - <de@ngelis.com>
 
 ---
-###License
+### License
 
 ```
 Copyright 2016 Christian De Angelis


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
